### PR TITLE
Centralized set table logic to reducers

### DIFF
--- a/src/actions/actionTypes.jsx
+++ b/src/actions/actionTypes.jsx
@@ -1,7 +1,5 @@
 export const SET_POP_UP = "SET_POP_UP";
-export const SET_SELECTED_TABLE = "SET_SELECTED_TABLE";
-export const SET_TABLE_INDEX = "SET_TABLE_INDEX";
-export const SET_TABLES = "SET_TABLES";
+export const SAVE_TABLE = "SAVE_TABLE";
 export const SET_VIEW = "SET_VIEW";
 export const EDIT_FIELD = "EDIT_FIELD";
 export const ADD_FIELD = "ADD_FIELD";

--- a/src/components/view/schemaView.jsx
+++ b/src/components/view/schemaView.jsx
@@ -3,13 +3,11 @@ import SchemaTable from './schemaTable';
 import styled from 'styled-components';
 import { Store } from '../../state/store';
 import { 
-  SET_TABLES, 
   SET_POP_UP, 
   SET_VIEW, 
-  EDIT_TABLE 
-
+  EDIT_TABLE, 
+  DELETE_TABLE
 } from '../../actions/actionTypes';
-import deepClone from  '../../utils/deepClone';
 
 /*-------------------- Styled Component --------------------*/
 
@@ -25,23 +23,16 @@ function SchemaView() {
 
   const { dispatch, state: { tables } } = useContext(Store);
 
-  const deleteTable = id => {
-    const newTables = deepClone(tables);
-    delete newTables[id];
-    dispatch({ type: SET_TABLES, payload: newTables });
-  }
-
   const tablesArray = Object.keys(tables).map(tableKey => (
     <SchemaTable
       tables={tables}
       key={tableKey}
       tableKey={tableKey}
       table={tables[tableKey]}
-      setTables={ payload => dispatch({ type: SET_TABLES, payload }) }
       setPopUp={ payload => dispatch({ type: SET_POP_UP, payload }) }
       setView={ payload => dispatch({ type: SET_VIEW, payload }) }
       style={{ margin: "10px" }}
-      deleteTable={deleteTable}
+      deleteTable={ payload => dispatch({ type: DELETE_TABLE, payload })}
       editTable={ payload => dispatch({ type: EDIT_TABLE, payload }) }
     />
   ))

--- a/src/components/view/tableForm.jsx
+++ b/src/components/view/tableForm.jsx
@@ -2,8 +2,7 @@ import React, { useContext } from 'react';
 import { Store } from '../../state/store';
 import { 
   SET_POP_UP, 
-  SET_TABLES,
-  SET_TABLE_INDEX,
+  SAVE_TABLE,
   ADD_FIELD,
   DELETE_FIELD,
   EDIT_FIELD,
@@ -14,7 +13,6 @@ import TableNameInput from './tableNameInput';
 import TableField from './tableField';
 import TableInput from './tableInput';
 import Draggable from 'react-draggable';
-import deepClone from '../../utils/deepClone';
 
 /*-------------------- Styled Components --------------------*/
 
@@ -109,15 +107,7 @@ const Buttons = styled.span`
 
 function TableForm() {
 
-  const {
-    dispatch,
-    state: {
-      selectedTable, 
-      tables, 
-      initialField, 
-      tableIndex 
-    }
-  } = useContext(Store);
+  const { dispatch, state: { selectedTable } } = useContext(Store);
 
   /*-------------------- Table Input Function --------------------*/
   const fieldInputs = [];
@@ -165,10 +155,7 @@ function TableForm() {
             </Button>
             <Button
               onClick={() => {
-                const newTables = deepClone(tables);
-                newTables[selectedTable.tableID] = selectedTable;
-                dispatch({ type: SET_TABLES, payload: newTables });
-                dispatch({ type: SET_TABLE_INDEX, payload: tableIndex + 1 });
+                dispatch({ type: SAVE_TABLE });
                 dispatch({ type: SET_POP_UP, payload: '' });
               }}>
               <i className="far fa-save" color="black" /> Save

--- a/src/state/store.jsx
+++ b/src/state/store.jsx
@@ -45,11 +45,14 @@ function reducer(state, action) {
       newState.selectedTable.type = action.payload;
       return { ...state, selectedTable: newState.selectedTable };
 
-    case "SET_TABLE_INDEX":
-      return { ...state, tableIndex: action.payload };
+    // This case will increment tableIndex regardless whether we're adding a new table or editing an existing one
+    case "SAVE_TABLE":
+      newState.tables[newState.selectedTable.tableID] = newState.selectedTable;
+      return { ...state, tables: newState.tables, tableIndex: newState.tableIndex + 1 };
 
-    case "SET_TABLES":
-      return { ...state, tables: action.payload };
+    case "DELETE_TABLE":
+      delete newState.tables[action.payload];
+      return { ...state, tables: newState.tables };
 
     case "SET_VIEW":
       return { ...state, view: action.payload };


### PR DESCRIPTION
Co-authored-by: Rodolfo Guzman <Rodolfoguzman147@gmail.com>

- Centralized 'SET_TABLES' logic from React functional components into reducer
- Split 'SET_TABLES' cases into two cases: 'SAVE_TABLE' and 'DELETE_TABLE'
- Note that 'SAVE_TABLE' increments tableIndex state regardless whether we're adding a new table or editing an existing one (shouldn't affect our app but may need to revisit)